### PR TITLE
feat: locate and use ARM toolchain from pros-vsc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -82,6 +94,7 @@ dependencies = [
  "cargo_metadata",
  "cfg-if",
  "clap",
+ "dirs",
  "fs-err",
  "home",
  "serde_json",
@@ -160,12 +173,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -190,6 +235,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "libc"
+version = "0.2.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +273,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -301,6 +389,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ fs-err = "2.9.0"
 home = "0.5.5"
 serde_json = "1.0.106"
 clap = { version = "4.4.2", features = ["derive"], optional = true }
+dirs = "5.0.1"
 
 [features]
 default = ["clap"]

--- a/src/armv7a-vexos-eabi.json
+++ b/src/armv7a-vexos-eabi.json
@@ -1,11 +1,12 @@
 {
+    "cpu": "cortex-a9",
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "emit-debug-gdb-scripts": false,
     "env": "newlib",
     "executables": true,
-    "features": "+v7,+thumb2,+soft-float,-neon,+strict-align",
+    "features": "+thumb2,+neon,+vfp3",
     "linker": "arm-none-eabi-gcc",
     "linker-flavor": "gcc",
     "llvm-target": "armv7a-none-eabi",
@@ -16,11 +17,12 @@
             "-nostartfiles",
             "-nostdlib",
             "-Wl,-Tv5.ld,-Tv5-common.ld,--gc-sections",
-            "-Wl,--start-group,-lpros,-lc,-lm,-lgcc,-lstdc++,--end-group"
+            "-Wl,--start-group,-lpros,-lc,--end-group"
         ]
     },
     "relocation-model": "static",
     "target-family": "unix",
     "target-pointer-width": "32",
-    "os": "vexos"
+    "os": "vexos",
+    "vendor": "vex"
 }

--- a/src/armv7a-vexos-eabi.json
+++ b/src/armv7a-vexos-eabi.json
@@ -1,12 +1,11 @@
 {
-    "cpu": "cortex-a9",
     "arch": "arm",
     "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "emit-debug-gdb-scripts": false,
     "env": "newlib",
     "executables": true,
-    "features": "+thumb2,+neon,+vfp3",
+    "features": "+v7,+thumb2,+soft-float,-neon,+strict-align",
     "linker": "arm-none-eabi-gcc",
     "linker-flavor": "gcc",
     "llvm-target": "armv7a-none-eabi",
@@ -17,12 +16,11 @@
             "-nostartfiles",
             "-nostdlib",
             "-Wl,-Tv5.ld,-Tv5-common.ld,--gc-sections",
-            "-Wl,--start-group,-lpros,-lc,--end-group"
+            "-Wl,--start-group,-lpros,-lc,-lm,-lgcc,-lstdc++,--end-group"
         ]
     },
     "relocation-model": "static",
     "target-family": "unix",
     "target-pointer-width": "32",
-    "os": "vexos",
-    "vendor": "vex"
+    "os": "vexos"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,6 @@ pub fn build(
             .arg("--target")
             .arg(&target_path);
 
-        println!("LINKER PATH: {}", linker_path());
-
         build_cmd
             .arg("--config")
             .arg(format!("target.armv7a-vexos-eabi.linker='{}'", linker_path()));


### PR DESCRIPTION
Detects local installations of the `arm-none-eabi-gcc` toolchain installed by the PROS vscode extension for both VSCode and VSCode Insiders on windows. This allows users of the extension to use `cargo-pros` without installing the toolchain themselves on windows.